### PR TITLE
Overhaul availability testing and add expected input languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Note that there is no way of specifying output languages, since these are govern
 
 In the simple case, web developers should call `ai.languageModel.create()`, and handle failures gracefully.
 
-However, if the web developer wants to provide a differentiated user experience, which lets users know ahead of time that the feature will not be possible or might require a download, they can use the promise-returning `ai.languageModel.createOptionsAvailable()` method. This method lets developers know, before calling `create()`, what is possible with the implementation.
+However, if the web developer wants to provide a differentiated user experience, which lets users know ahead of time that the feature will not be possible or might require a download, they can use the promise-returning `ai.languageModel.availability()` method. This method lets developers know, before calling `create()`, what is possible with the implementation.
 
 The method will return a promise that fulfills with one of the following availability values:
 
@@ -357,7 +357,7 @@ An example usage is the following:
 ```js
 const options = { expectedInputLanguages: ["en", "es"], temperature: 2 };
 
-const supportsOurUseCase = await ai.languageModel.createOptionsAvailable(options);
+const supportsOurUseCase = await ai.languageModel.availability(options);
 
 if (supportsOurUseCase !== "no") {
   if (supportsOurUseCase === "after-download") {
@@ -433,7 +433,7 @@ enum AICapabilityAvailability { "readily", "after-download", "no" };
 [Exposed=(Window,Worker), SecureContext]
 interface AILanguageModelFactory {
   Promise<AILanguageModel> create(optional AILanguageModelCreateOptions options = {});
-  Promise<AICapabilityAvailability> createOptionsAvailable(optional AILanguageModelCreateCoreOptions options = {});
+  Promise<AICapabilityAvailability> availability(optional AILanguageModelCreateCoreOptions options = {});
   Promise<AILanguageModelInfo?> params();
 };
 


### PR DESCRIPTION
Remove the `ai.languageModel.capabilities()` method and its accompanying `AILanguageModelCapabilities` class. Instead, replace it with:

* `ai.languageModel.availability(options)`, which takes the same options as `ai.languageModel.create()`, and returns the corresponding availability.
* `ai.languageModel.params()`, which returns the default and max params (currently top-K and temperature).

Additionally, add the `expectedInputLanguages` option to `create()` and `availability()`. The addition of this option to `create()` allows the web developer to signal the expected input languages ahead of time, allowing the downloading of additional material, or fast-failing if the additional material cannot be supported. The addition of this option to `availability()` replaces the `(await ai.languageModel.capabilities()).languageAvailable()` method.

Closes https://github.com/webmachinelearning/prompt-api/issues/29; see especially https://github.com/webmachinelearning/prompt-api/issues/29#issuecomment-2288105020.

See also https://github.com/webmachinelearning/writing-assistance-apis/pull/22 and https://github.com/webmachinelearning/translation-api/pull/31.