### PR TITLE
Add structured outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-While processing the JSON schema, in cases where the user agent detects unsupported schema or notices output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message.
-API does not guarantee perfect conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
+While processing the JSON schema, in cases where the user agent detects unsupported schema or notices output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message. API does not guarantee conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-While processing the JSON schema, in cases where the user agent detects unsupported schema or notices output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message. API does not guarantee conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
+While processing the JSON schema, in cases where the user agent detects unsupported schema or detects output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message. API does not guarantee conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-If perfect conformance is required, developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced by the API.
+While processing the JSON schema, in cases where the user agent detects unsupported schema or notices output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message.
+API does not guarantee perfect conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ interface AILanguageModelParams {
   readonly attribute float maxTemperature;
 };
 
-[Exposed=Window]
+[Exposed=(Window,Worker)]
 interface AILanguageModelResponseSchema {
   constructor(object responseJSONSchemaObject);
 }

--- a/README.md
+++ b/README.md
@@ -173,6 +173,36 @@ console.log(await promptWithCalculator("What is 2 + 2?"));
 
 We'll likely explore more specific APIs for tool- and function-calling in the future; follow along in [issue #7](https://github.com/webmachinelearning/prompt-api/issues/7).
 
+### Structured output or JSON output
+
+To help with programmatic processing of language model responses, the prompt API supports structured outputs defined by a JSON schema.
+
+```js
+const session = await ai.languageModel.create();
+
+const responseJSONSchemaObj = new AILanguageModelResponseSchema({
+  "type" : "object",
+  "required" : ["Rating"],
+  "additionalProperties" : false,
+  "properties" : {
+    "Rating": {
+      "type": "number"
+      "minimum": 0,
+      "maximum": 5
+    }
+  }
+});
+
+// Prompt the model and wait for the json response to come back.
+const result = await session.prompt("Summarize this feedback into a rating between 0-5: "+
+  "The food was delicious, service was excellent, will recommend.",
+  {responseJSONSchema : responseJSONSchemaObj}
+);
+console.log(result);
+```
+
+The responseJSONSchema field in the prompt options passed to session.prompt can accept a JSON Schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts. If required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced by the API.
+
 ### Configuration of per-session parameters
 
 In addition to the `systemPrompt` and `initialPrompts` options shown above, the currently-configurable model parameters are [temperature](https://huggingface.co/blog/how-to-generate#sampling) and [top-K](https://huggingface.co/blog/how-to-generate#top-k-sampling). The `params()` API gives the default, minimum, and maximum values for these parameters.
@@ -465,6 +495,11 @@ interface AILanguageModelParams {
   readonly attribute float maxTemperature;
 };
 
+[Exposed=Window]
+interface AILanguageModelResponseSchema {
+  constructor(object responseJSONSchemaObject);
+}
+
 dictionary AILanguageModelCreateCoreOptions {
   [EnforceRange] unsigned long topK;
   float temperature;
@@ -490,6 +525,7 @@ dictionary AILanguageModelPrompt {
 };
 
 dictionary AILanguageModelPromptOptions {
+  object responseJSONSchema;
   AbortSignal signal;
 };
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ const result = await session.prompt("Summarize this feedback into a rating betwe
 console.log(result);
 ```
 
-The responseJSONSchema field in the prompt options passed to session.prompt can accept a JSON Schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts. If required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced by the API.
+The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
+
+If perfect conformance is required, developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced by the API.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -181,16 +181,16 @@ To help with programmatic processing of language model responses, the prompt API
 const session = await ai.languageModel.create();
 
 const responseJSONSchemaObj = new AILanguageModelResponseSchema({
-  "type" : "object",
-  "required" : ["Rating"],
-  "additionalProperties" : false,
-  "properties" : {
-    "Rating": {
-      "type": "number"
-      "minimum": 0,
-      "maximum": 5
-    }
-  }
+  type: "object",
+  required: ["Rating"],
+  additionalProperties: false,
+  properties: {
+    Rating: {
+      type: "number",
+      minimum: 0,
+      maximum: 5,
+    },
+  },
 });
 
 // Prompt the model and wait for the json response to come back.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-While processing the JSON schema, in cases where the user agent detects unsupported schema a `"NotSupportedError"` `DOMException`, will be raised with appropriate error message. The result value returned is a string, that can be parsed with `JSON.parse()`. If the user agent detects the prompt response as not being complaint with the schema an `"AbortError"` `DOMException` will be raised.
+While processing the JSON schema, in cases where the user agent detects unsupported schema a `"NotSupportedError"` `DOMException`, will be raised with appropriate error message. The result value returned is a string, that can be parsed with `JSON.parse()`. If the user agent is unable to produce a response that is compliant with the schema, a `"SyntaxError"` `DOMException` will be raised.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-While processing the JSON schema, in cases where the user agent detects unsupported schema a `"NotSupportedError"` `DOMException`, will be raised with appropriate error message. The result value returned is a string, that can be parsed with JSON.parse(). If the user agent detects the prompt response as not being complaint with the schema an `"AbortError"` `DOMException` will be raised.
+While processing the JSON schema, in cases where the user agent detects unsupported schema a `"NotSupportedError"` `DOMException`, will be raised with appropriate error message. The result value returned is a string, that can be parsed with `JSON.parse()`. If the user agent detects the prompt response as not being complaint with the schema an `"AbortError"` `DOMException` will be raised.
 
 ### Configuration of per-session parameters
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ console.log(result);
 
 The `responseJSONSchema` option for `prompt()` and `promptStreaming()` can also accept a JSON schema directly as a JavaScript object. This is particularly useful for cases where the schema is not reused for other prompts.
 
-While processing the JSON schema, in cases where the user agent detects unsupported schema or detects output not compliant with the schema an `"AbortError"` `DOMException`, will be raised with appropriate error message. API does not guarantee conformance of the output to specified schema, if required developers should validate the response against the schema to ensure full conformity, as some aspects of the JSON schema may not be enforced.
+While processing the JSON schema, in cases where the user agent detects unsupported schema a `"NotSupportedError"` `DOMException`, will be raised with appropriate error message. The result value returned is a string, that can be parsed with JSON.parse(). If the user agent detects the prompt response as not being complaint with the schema an `"AbortError"` `DOMException` will be raised.
 
 ### Configuration of per-session parameters
 


### PR DESCRIPTION
This change adds support for structured outputs, JSON outputs to the prompt API, following up from issue https://github.com/webmachinelearning/prompt-api/issues/35.

We are planning to add support for structured outputs to chromium https://issues.chromium.org/issues/391919456, tracks the dev work in chromium.