### PR TITLE
Rename innermost prompt property from "content" to "value"

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ typedef (
   sequence<LanguageModelMessage>
   // Shorthand per the below comment
   or sequence<LanguageModelMessageShorthand>
-  // Shorthand for [{ role: "user", content: [{ type: "text", content: providedValue }] }]
+  // Shorthand for [{ role: "user", content: [{ type: "text", value: providedValue }] }]
   or DOMString
 ) LanguageModelPrompt;
 
@@ -791,7 +791,7 @@ dictionary LanguageModelMessage {
   required sequence<LanguageModelMessageContent> content;
 };
 
-// Shorthand for { role: providedValue.role, content: [{ type: "text", content: providedValue.content }] }
+// Shorthand for { role: providedValue.role, content: [{ type: "text", value: providedValue.content }] }
 dictionary LanguageModelMessageShorthand {
   required LanguageModelMessageRole role;
   required DOMString content;
@@ -799,7 +799,7 @@ dictionary LanguageModelMessageShorthand {
 
 dictionary LanguageModelMessageContent {
   required LanguageModelMessageType type;
-  required LanguageModelMessageContentValue content;
+  required LanguageModelMessageValue value;
 };
 
 enum LanguageModelMessageRole { "system", "user", "assistant" };
@@ -811,7 +811,7 @@ typedef (
   or AudioBuffer
   or BufferSource
   or DOMString
-) LanguageModelMessageContentValue;
+) LanguageModelMessageValue;
 ```
 
 ### Instruction-tuned versus base models


### PR DESCRIPTION
This makes it clear that "content" is always a peer to "role", whereas "value" only appears when you're using the longhand content array form which takes { type, value } pairs.

Most existing APIs instead do { type: "image", image: theValue }, { type: "text", text: theValue }, etc. This is not really appropriate for a web API, so we don't end up copying them exactly. But none of the existing APIs use "content" at both the outer and inner levels, so it's probably a good idea to avoid that path.