### PR TITLE
Fix IDL for prompts, again

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ dictionary LanguageModelCreateOptions : LanguageModelCreateCoreOptions {
   AbortSignal signal;
   AICreateMonitorCallback monitor;
 
-  LanguageModelInitialPrompts initialPrompts;
+  sequence<LanguageModelMessage> initialPrompts;
 };
 
 dictionary LanguageModelPromptOptions {
@@ -769,32 +769,16 @@ dictionary LanguageModelExpected {
 // The argument to the prompt() method and others like it
 
 typedef (
-  // Canonical format
   sequence<LanguageModelMessage>
-  // Shorthand per the below comment
-  or sequence<LanguageModelMessageShorthand>
-  // Shorthand for [{ role: "user", content: [{ type: "text", value: providedValue }] }]
+  // Shorthand for `[{ role: "user", content: [{ type: "text", value: providedValue }] }]`
   or DOMString
 ) LanguageModelPrompt;
 
-// The initialPrompts value omits the single string shorthand
-typedef (
-  // Canonical format
-  sequence<LanguageModelMessage>
-  // Shorthand per the below comment
-  or sequence<LanguageModelMessageShorthand>
-) LanguageModelInitialPrompts;
-
-
 dictionary LanguageModelMessage {
   required LanguageModelMessageRole role;
-  required sequence<LanguageModelMessageContent> content;
-};
 
-// Shorthand for { role: providedValue.role, content: [{ type: "text", value: providedValue.content }] }
-dictionary LanguageModelMessageShorthand {
-  required LanguageModelMessageRole role;
-  required DOMString content;
+  // The DOMString branch is shorthand for `[{ type: "text", value: providedValue }]`
+  required (DOMString or sequence<LanguageModelMessageContent>) content;
 };
 
 dictionary LanguageModelMessageContent {


### PR DESCRIPTION
The previous IDL had an invalid union of two `sequence<dictionaries>`, which are not distinguishable.

This new approach is mostly the same. However, it also allows mixtures of shorthand and non-shorthand contents, e.g. `[{ role: "user", content: "Foo" }, { role: "user", content: [{ type: "text", value: "Bar" }] }]`. That seems like a good thing.

@michaelwasserman PTAL